### PR TITLE
Suggestions for arguments and beyond

### DIFF
--- a/commands/bench/bench.cmd.json
+++ b/commands/bench/bench.cmd.json
@@ -1,8 +1,6 @@
 {
   "$schema": "../../schema.cmd.json",
   "command": {
-    "id": "bench",
-    "label": "Bench",
     "description": "Runs `benchmark pallet` or `benchmark overhead` against your PR and commits back updated weights",
     "configuration": {
       "gitlab": {
@@ -10,115 +8,93 @@
           "tags": ["bench-bot"]
         },
         "variables": {}
-      },
-      "commandStart": [ "\"$PIPELINE_SCRIPTS_DIR/commands/bench/bench-bot.sh\"" ]
-    },
-    "presets": [
-      {
-        "label": "Pallet Benchmark for Substrate",
-        "repos": ["substrate"],
-        "args": [
-          { "label": "Type of bench", "type_one_of": [ "pallet" ] },
-          { "label": "Runtime", "type_one_of": ["dev"] },
-          { "label": "pallet", "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
-        ]
-      },
-      {
-        "label": "Pallet Benchmark for Polkadot",
-        "repos": ["polkadot"],
-        "args": [
-          { "label": "Type of bench", "type_one_of": ["runtime", "xcm"] },
-          { "label": "Runtime", "type_many_of": ["kusama-dev", "polkadot-dev", "rococo-dev", "westend-dev"] },
-          { "label": "Pallet", "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
-        ]
-      },
-      {
-        "label": "Pallet Benchmark for Cumulus [assets]",
-        "repos": ["cumulus"],
-        "args": [
-          { "label": "Type of bench", "type_one_of": ["xcm", "pallet"] },
-          { "label": "Runtime", "type_many_of": ["statemine", "statemint", "test-utils", "westmint"] },
-          { "label": "Kind", "type_one_of": ["asset"] },
-          { "label": "Pallet", "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
-        ]
-      },
-      {
-        "label": "Pallet Benchmark for Cumulus [collectives]",
-        "repos": ["cumulus"],
-        "args": [
-          { "label": "Type of bench", "type_one_of": ["xcm", "pallet"] },
-          { "label": "Runtime", "type_many_of": ["collectives-polkadot"] },
-          { "label": "Kind", "type_one_of": ["collectives"] },
-          { "label": "Pallet", "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
-        ]
-      },
-      {
-        "label": "Pallet Benchmark for Cumulus [contracts]",
-        "repos": ["cumulus"],
-        "args": [
-          { "label": "Type of bench", "type_one_of": ["xcm", "pallet"] },
-          { "label": "Runtime", "type_many_of": ["contracts-rococo"] },
-          { "label": "Kind", "type_one_of": ["contracts"] },
-          { "label": "Pallet", "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
-        ]
-      },
-      {
-        "label": "Pallet Benchmark for Cumulus [starters]",
-        "repos": ["cumulus"],
-        "args": [
-          { "label": "Type of bench", "type_one_of": ["xcm", "pallet"] },
-          { "label": "Runtime", "type_many_of": ["seedling", "shell"] },
-          { "label": "Kind", "type_one_of": ["starters"] },
-          { "label": "Pallet", "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
-        ]
-      },
-      {
-        "label": "Pallet Benchmark for Cumulus [testing]",
-        "repos": ["cumulus"],
-        "args": [
-          { "label": "Type of bench", "type_one_of": ["xcm", "pallet"] },
-          { "label": "Runtime", "type_many_of": ["penpal", "rococo-parachain"] },
-          { "label": "Kind", "type_one_of": ["testing"] },
-          { "label": "Pallet", "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
-        ]
-      },
-      {
-        "label": "Pallet Benchmark for Cumulus [testing]",
-        "repos": ["cumulus"],
-        "args": [
-          { "label": "Type of bench", "type_one_of": ["xcm", "pallet"] },
-          { "label": "Runtime", "type_many_of": ["penpal", "rococo-parachain"] },
-          { "label": "Kind", "type_one_of": ["testing"] },
-          { "label": "Pallet", "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
-        ]
-      },
-      {
-        "label": "Overhead for Substrate",
-        "description": "Runs `benchmark overhead` and commits back to PR the updated `extrinsic_weights.rs` files",
-        "repos": ["substrate"],
-        "args": [
-          { "label": "Type of bench", "type_one_of": ["overhead"] }
-        ]
-      },
-      {
-        "label": "Overhead for Polkadot",
-        "description": "Runs `benchmark overhead` and commits back to PR the updated `extrinsic_weights.rs` files",
-        "repos": ["polkadot"],
-        "args": [
-          { "label": "Type of bench", "type_one_of": ["overhead"] },
-          { "label": "Runtime", "type_many_of": ["kusama-dev", "polkadot-dev", "rococo-dev", "westend-dev"] }
-        ]
-      },
-      {
-        "label": "Overhead for Cumulus",
-        "description": "Runs `benchmark overhead` and commits back to PR the updated `extrinsic_weights.rs` files",
-        "repos": ["cumulus"],
-        "args": [
-          { "label": "Type of bench", "type_one_of": ["overhead"] },
-          { "label": "Kind", "type_one_of": ["asset"] },
-          { "label": "Runtime", "type_many_of": ["statemine", "statemint", "test-utils", "westmint"] }
-        ]
       }
-    ]
+    },
+    "presets": {
+      "substrate": {
+        "repos": ["substrate"],
+        "args": {
+          "type": { "short": "t", "type_one_of": [ "pallet" ], "description": "Type of bench" },
+          "runtime": { "type_one_of": [ "dev" ] },
+          "pallet": { "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
+        }
+      },
+      "polkadot": {
+        "repos": ["polkadot"],
+        "args": {
+          "type": { "short": "t", "type_one_of": [ "runtime", "xcm" ], "description": "Type of bench", "default": "runtime" },
+          "runtime": { "type_many_of": ["kusama-dev", "polkadot-dev", "rococo-dev", "westend-dev"] },
+          "pallet": { "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
+        }
+      },
+      "cumulus-assets": {
+        "repos": ["cumulus"],
+        "args": {
+          "type": { "short": "t", "type_one_of": ["xcm", "pallet"], "description": "Type of bench" },
+          "runtime": { "type_many_of": ["statemine", "statemint", "test-utils", "westmint"] },
+          "kind": { "type_one_of": ["asset"] },
+          "pallet": { "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
+        }
+      },
+      "cumulus-collectives": {
+        "repos": ["cumulus"],
+        "args": {
+          "type": { "short": "t", "type_one_of": ["xcm", "pallet"], "description": "Type of bench", "default": "pallet" },
+          "runtime": { "type_many_of": ["collectives-polkadot"] },
+          "kind": { "type_one_of": ["collectives"] },
+          "pallet": { "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
+        }
+      },
+      "cumulus-contracts": {
+        "repos": ["cumulus"],
+        "args": {
+          "type": { "short": "t", "type_one_of": ["xcm", "pallet"], "description": "Type of bench", "default": "pallet" },
+          "runtime": { "type_many_of": ["contracts-rococo"] },
+          "kind": { "type_one_of": ["contracts"] },
+          "pallet": { "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
+        }
+      },
+      "cumulus-starters": {
+        "repos": ["cumulus"],
+        "args": {
+          "type": { "short": "t", "type_one_of": ["xcm", "pallet"], "description": "Type of bench", "default": "pallet" },
+          "runtime": { "type_many_of": ["seedling", "shell"], "default": "shell" },
+          "kind": { "type_one_of": ["starters"] },
+          "pallet": { "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
+        }
+      },
+      "cumulus-testing": {
+        "repos": ["cumulus"],
+        "args": {
+          "type": { "short": "t", "type_one_of": ["xcm", "pallet"], "description": "Type of bench", "default": "pallet" },
+          "runtime": { "type_many_of": ["penpal", "rococo-parachain"], "default": "penpal" },
+          "kind": { "type_one_of": ["testing"] },
+          "pallet": { "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
+        }
+      },
+      "substrate-overhead": {
+        "repos": ["substrate"],
+        "description": "Runs `benchmark overhead` and commits back to PR the updated `extrinsic_weights.rs` files",
+        "args": {
+          "type": { "type_one_of": [ "overhead" ], "description": "Type of bench" },
+        }
+      },
+      "polkadot-overhead": {
+        "repos": ["polkadot"],
+        "args": {
+          "type": { "type_one_of": [ "overhead" ], "description": "Type of bench" },
+          "runtime": { "type_many_of": ["kusama-dev", "polkadot-dev", "rococo-dev", "westend-dev"] },
+          "pallet": { "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/" }
+        }
+      },
+      "cumulus-overhead": {
+        "repos": ["cumulus"],
+        "args": {
+          "type": { "type_one_of": [ "overhead" ], "description": "Type of bench" },
+          "runtime": { "type_many_of": ["statemine", "statemint", "test-utils", "westmint"], "default": "statemine" },
+          "kind": { "type_one_of": ["asset"] }
+        }
+      }
+    }
   }
 }

--- a/commands/bench/bench.sh
+++ b/commands/bench/bench.sh
@@ -50,7 +50,7 @@ main() {
 
   set -x
   # Runs the command to generate the weights
-  . "$(dirname "${BASH_SOURCE[0]}")/build-bench-args.sh" "$@"
+  . "$(dirname "${BASH_SOURCE[0]}")/build-bench-args.sh"
   set +x
 
   # in case we used diener to patch some dependency during benchmark execution,
@@ -73,4 +73,4 @@ main() {
   git push github "HEAD:${GH_CONTRIBUTOR_BRANCH}"
 }
 
-main "$@"
+main

--- a/commands/fmt/fmt.cmd.json
+++ b/commands/fmt/fmt.cmd.json
@@ -4,8 +4,12 @@
     "name": "fmt",
     "label": "FMT",
     "description": "rustFMT. Formatting Rust code according to style guidelines and commits to your PR.",
-    "configuration": { "gitlab": { "job": { "tags": ["linux-docker"] }, "variables": {} },
-      "commandStart": [ "\"$PIPELINE_SCRIPTS_DIR/commands/fmt/fmt.sh\"" ]
+    "configuration": {
+      "gitlab": {
+        "job": {
+          "tags": ["linux-docker"]
+        }
+      }
     }
   }
 }

--- a/commands/fmt/fmt.sh
+++ b/commands/fmt/fmt.sh
@@ -24,4 +24,4 @@ main() {
   git push github "HEAD:${GH_CONTRIBUTOR_BRANCH}"
 }
 
-main "$@"
+main

--- a/commands/sample/sample.cmd.json
+++ b/commands/sample/sample.cmd.json
@@ -2,28 +2,26 @@
   "$schema": "../../schema.cmd.json",
   "command": {
     "id": "sample",
-    "label":"123",
     "configuration": {
       "gitlab": {
         "job": {
           "tags": ["kubernetes-parity-build"],
           "variables": {}
         }
-      },
-      "commandStart": ["echo"]
-    },
-    "presets": [
-      {
-        "label": "echo something",
-        "description": "Outputs your echo string",
-        "repos": ["polkadot"],
-        "args": [
-          {
-            "label": "Pass your echo string",
-            "type_rule": ".*"
-          }
-        ]
       }
-    ]
+    },
+    "presets": {
+      "default": {
+        "repos": ["polkadot"],
+        "description": "Outputs your echo string",
+        "args": {
+          "input": {
+            "short": "i",
+            "type_rule": ".*",
+            "description": "String to echo"
+          }
+        }
+      }
+    }
   }
 }

--- a/commands/sample/sample.sh
+++ b/commands/sample/sample.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+shopt -s inherit_errexit
+
+. "$(dirname "${BASH_SOURCE[0]}")/../cmd_runner.sh"
+
+echo "${ARGS[input]}"

--- a/commands/try-runtime/try-runtime.cmd.json
+++ b/commands/try-runtime/try-runtime.cmd.json
@@ -9,18 +9,22 @@
           "tags": ["linux-docker"]
         },
         "variables": {}
-      },
-      "commandStart": [ "\"$PIPELINE_SCRIPTS_DIR/commands/try-runtime/try-runtime.sh\"" ]
-    },
-    "presets": [
-      {
-        "title": "try-runtime",
-        "description": "Try-Runtime - runs `cargo run --release --quiet --features=try-runtime try-runtime --chain=<CHAIN> --execution=Wasm --no-spec-check-panic on-runtime-upgrade live --uri=<URI>`",
-        "args": [
-          { "label": "Chain", "rule": "/^[a-z_-]+$/" },
-          { "label": "URI", "rule": [".*"] }
-        ]
       }
-    ]
+    },
+    "presets": {
+      "default": {
+        "description": "Try-Runtime - runs `cargo run --release --quiet --features=try-runtime try-runtime --chain=<CHAIN> --execution=Wasm --no-spec-check-panic on-runtime-upgrade live --uri=<URI>`",
+        "args": {
+          "chain": {
+            "short": "c",
+            "type_rule": "/^[a-z_-]+$/"
+          },
+          "uri": {
+            "short": "u",
+            "type_rule": [".+"]
+          }
+        }
+      }
+    }
   }
 }

--- a/commands/try-runtime/try-runtime.sh
+++ b/commands/try-runtime/try-runtime.sh
@@ -10,12 +10,12 @@ main() {
 
   cmd_runner_apply_patches --setup-cleanup true
 
-  local chain="$1"
-  local uri="$2"
+  local chain="${ARGS[chain]}"
+  local uri="${ARGS[uri]}"
 
-  if [ -z "$chain" ] || [ -z "$uri" ];
-  then
-      die "chain and uri arguments should be provided"
+  if [ -z "$chain" ] || [ -z "$uri" ]; then
+    # this is probably redundant, as the validation should be performed on bot's side
+    die "chain and uri arguments should be provided"
   fi
 
   local preset_args=(
@@ -38,7 +38,7 @@ main() {
 
   set -x
   export RUST_LOG="${RUST_LOG:-remote-ext=debug,runtime=trace}"
-  cargo "${preset_args[@]}" "$@"
+  cargo "${preset_args[@]}"
 }
 
-main "$@"
+main

--- a/schema.cmd.json
+++ b/schema.cmd.json
@@ -6,12 +6,6 @@
     "command": {
       "type": "object",
       "properties": {
-        "id": {
-          "type": "string"
-        },
-        "label": {
-          "type": "string"
-        },
         "description": {
           "type": "string"
         },
@@ -46,13 +40,10 @@
           }
         },
         "presets": {
-          "type": "array",
-          "items": {
+          "type": "object",
+          "additionalProperties": {
             "type": "object",
             "properties": {
-              "label": {
-                "type": "string"
-              },
               "description": {
                 "type": "string"
               },
@@ -69,11 +60,19 @@
                 }
               },
               "args": {
-                "type": "array",
+                "type": "object",
+                "additionalProperties": {
+                  "description": {
+                    "type": "string"
+                  }
+                },
                 "items": {
                   "type": "object",
                   "properties": {
-                    "label": {
+                    "default": {
+                      "type": "string"
+                    },
+                    "short": {
                       "type": "string"
                     },
                     "type_one_of": {
@@ -92,9 +91,15 @@
                       "type": "string"
                     },
                     "anyOf": [
-                      {"required": ["label", "type_one_of"]},
-                      {"required": ["label", "type_many_of"]},
-                      {"required": ["label", "type_rule"]}
+                      {
+                        "required": ["type_one_of"]
+                      },
+                      {
+                        "required": ["type_many_of"]
+                      },
+                      {
+                        "required": ["type_rule"]
+                      }
                     ]
                   }
                 }
@@ -103,14 +108,8 @@
           }
         }
       },
-      "required": [
-        "id",
-        "label",
-        "configuration"
-      ]
+      "required": ["configuration"]
     }
   },
-  "required": [
-    "command"
-  ]
+  "required": ["command"]
 }


### PR DESCRIPTION
### Questions that arose
1. `id` field in commands seems redundant: it brings ambiguity between itself and the file name. I'd say let's use file name only.
2. WDYT: get rid from `label`, leave only id (force same CLI-friendly names for both CLI and UI) + description?
3. Do we display arguments for presets where the type is `type_one_of` with a single argument inside? If we still want to show it, should we automatically mark those as default, as it is the only possible option, and we shouldn't force people to type it all the time?
4. For `bench`, `runtime` argument is a `type_many_of`? Sure about that? How would it work?
5. WDYT: default values for args?
6. WDYT: short options for args? So not only `--type` would work, but also `-t`.
7. WDYT: Pass to scripts not only `ARGS`, but also `REPOSITORY` and `PRESET`
8. commandStart seems also to be redundant. We're already using folder name for `*.cmd.json` (it has to be the same, right?), so why would we invent anything for `*.sh`? Hope that it's not just for `sample` command. If so, let's add a simple script there, but remove `commandStart` from all other scripts.
9. WDYT: default presets, which can be omitted? See "sample"

### How does calling the commands look with suggested changes?

bot <command> <preset> 
 bot bench polkadot --type=runtime
bot bench cumulus-starters -t xcm
bot bench cumulus-assets -t xcm -r statemine,westmint,test-utils

bot sample -i "Hello there!"