### PR TITLE
Add overhead and xcm benchmarks for Trappist

### DIFF
--- a/commands/bench-all/bench-all.cmd.json
+++ b/commands/bench-all/bench-all.cmd.json
@@ -32,7 +32,7 @@
         "description": "Pallet Benchmark for Trappist",
         "repos": ["trappist"],
         "args": {
-          "runtime":    { "label": "Runtime", "type_one_of": ["trappist"] }
+          "runtime":    { "label": "Runtime", "type_one_of": ["trappist", "stout"] }
         }
       }
     }

--- a/commands/bench/bench.cmd.json
+++ b/commands/bench/bench.cmd.json
@@ -128,9 +128,17 @@
         "description": "Pallet Benchmark for Trappist for specific pallet",
         "repos": ["trappist"],
         "args": {
-          "subcommand": { "label": "Subcommand", "type_one_of": ["runtime"] },
-          "runtime":    { "label": "Runtime", "type_one_of": ["trappist"] },
+          "subcommand": { "label": "Subcommand", "type_one_of": ["runtime", "xcm"] },
+          "runtime":    { "label": "Runtime", "type_one_of": ["trappist", "stout"] },
           "pallet":     { "label": "Pallet", "type_rule": "/^([a-z_]+)([:]{2}[a-z_]+)?$/", "example": "pallet_name" }
+        }
+      },
+      "trappist-overhead": {
+        "description": "Runs `benchmark overhead` and commits back to PR",
+        "repos": ["trappist"],
+        "args": {
+          "subcommand": { "label": "Subcommand", "type_one_of": ["overhead"] },
+          "runtime":    { "label": "Runtime", "type_one_of": ["trappist", "stout"] }
         }
       }
     }

--- a/commands/bench/lib/bench-overhead.sh
+++ b/commands/bench/lib/bench-overhead.sh
@@ -45,6 +45,15 @@ bench_overhead() {
         --chain="$runtime"
       )
     ;;
+    trappist)
+      local runtime="$2"
+      args=(
+        "${bench_overhead_common_args[@]}"
+        --header=./templates/file_header.txt
+        --weight-path="./runtime/$runtime/src/weights"
+        --chain="$runtime-dev"
+      )
+    ;;
     *)
       die "Repository $repository is not supported in bench_overhead"
     ;;

--- a/commands/bench/lib/bench-pallet.sh
+++ b/commands/bench/lib/bench-pallet.sh
@@ -144,19 +144,26 @@ bench_pallet() {
     ;;
     trappist)
       local pallet="$3"
-      local weights_dir="./runtime/${runtime}/src/weights"
+      local weights_dir="./runtime/$runtime/src/weights"
 
       args=(
         --features=runtime-benchmarks
         "${bench_pallet_common_args[@]}"
         --pallet="$pallet"
-        --chain="dev"
+        --chain="${runtime}-dev"
+        --header=./templates/file_header.txt
       )
 
       case "$kind" in
         runtime)
           args+=(
             --output="${weights_dir}/"
+          )
+        ;;
+        xcm)
+          args+=(
+            --template=./templates/xcm-bench-template.hbs
+            --output="${weights_dir}/xcm/"
           )
         ;;
         *)


### PR DESCRIPTION
 - add overhead benchmarks
 - add xcm benchmarks
 - add `stout` runtime