### PR TITLE
Update bench-all-cumulus.sh

### DIFF
--- a/commands/bench/lib/bench-all-cumulus.sh
+++ b/commands/bench/lib/bench-all-cumulus.sh
@@ -102,7 +102,7 @@ run_cumulus_bench() {
 
 
 echo "[+] Compiling benchmarks..."
-cargo build --profile production --locked --features=runtime-benchmarks -p polkadot-parachain
+cargo build --profile production --locked --features=runtime-benchmarks
 
 # Assets
 run_cumulus_bench assets statemine


### PR DESCRIPTION
Removed ` -p polkadot-parachain` as it started failing with 

```
+++ cargo build --profile production --locked --features=runtime-benchmarks -p polkadot-parachain
error: cannot specify features for packages outside of workspace
```