### PR TITLE
Removed `--execution=wasm`

### DIFF
--- a/commands/bench/lib/bench-all-cumulus.sh
+++ b/commands/bench/lib/bench-all-cumulus.sh
@@ -56,7 +56,6 @@ run_cumulus_bench() {
     $POLKADOT_PARACHAIN benchmark pallet \
       $extra_args \
       --chain="${benchmarkRuntimeChain}" \
-      --execution=wasm \
       --wasm-execution=compiled \
       --pallet="$pallet" \
       --no-storage-info \

--- a/commands/bench/lib/bench-all-polkadot.sh
+++ b/commands/bench/lib/bench-all-polkadot.sh
@@ -20,7 +20,6 @@ echo "[+] Benchmarking block and extrinsic overheads..."
 OUTPUT=$(
   $POLKADOT_BIN benchmark overhead \
   --chain="${runtime}-dev" \
-  --execution=wasm \
   --wasm-execution=compiled \
   --weight-path="runtime/${runtime}/constants/src/weights/" \
   --warmup=10 \

--- a/commands/bench/lib/bench-all-substrate.sh
+++ b/commands/bench/lib/bench-all-substrate.sh
@@ -79,7 +79,6 @@ echo "[+] Benchmarking block and extrinsic overheads..."
 OUTPUT=$(
   $SUBSTRATE benchmark overhead \
   --chain=dev \
-  --execution=wasm \
   --wasm-execution=compiled \
   --weight-path="./frame/support/src/weights/" \
   --header="./HEADER-APACHE2" \
@@ -107,7 +106,6 @@ for PALLET in "${PALLETS[@]}"; do
     --no-median-slopes \
     --no-min-squares \
     --extrinsic="*" \
-    --execution=wasm \
     --wasm-execution=compiled \
     --heap-pages=4096 \
     --output="$WEIGHT_FILE" \

--- a/commands/bench/lib/bench-all-trappist.sh
+++ b/commands/bench/lib/bench-all-trappist.sh
@@ -28,7 +28,6 @@ echo "[+] Benchmarking block and extrinsic overheads..."
 OUTPUT=$(
   $TRAPPIST_BIN benchmark overhead \
   --chain=$chain \
-  --execution=wasm \
   --wasm-execution=compiled \
   --weight-path="./runtime/${runtime}/src/weights/" \
   --warmup=10 \
@@ -83,7 +82,6 @@ for PALLET in "${PALLETS[@]}"; do
     --no-min-squares \
     --pallet="$PALLET" \
     --extrinsic="*" \
-    --execution=wasm \
     --wasm-execution=compiled \
     --header=./templates/file_header.txt \
     --output="./runtime/${runtime}/src/weights/${output_file}" 2>&1

--- a/commands/bench/lib/bench-overhead.sh
+++ b/commands/bench/lib/bench-overhead.sh
@@ -8,7 +8,6 @@ bench_overhead_common_args=(
   --
   benchmark
   overhead
-  --execution=wasm
   --wasm-execution=compiled
   --warmup=10
   --repeat=100

--- a/commands/bench/lib/bench-pallet.sh
+++ b/commands/bench/lib/bench-pallet.sh
@@ -11,7 +11,6 @@ bench_pallet_common_args=(
   --steps=50
   --repeat=20
   --extrinsic="*"
-  --execution=wasm
   --wasm-execution=compiled
   --heap-pages=4096
   --json-file="${ARTIFACTS_DIR}/bench.json"


### PR DESCRIPTION
Looks like this argument was removed from substrate