### PR TITLE
Remove trappist workaround

### DIFF
--- a/commands/bench-all/bench-all.cmd.json
+++ b/commands/bench-all/bench-all.cmd.json
@@ -40,6 +40,7 @@
         "repos": ["trappist"],
         "args": {
           "runtime":      { "label": "Runtime", "type_one_of": ["trappist", "stout"] }
+          "target_dir":   { "label": "Target Directory", "type_string": "trappist" }
         }
       }
     }

--- a/commands/bench-all/bench-all.cmd.json
+++ b/commands/bench-all/bench-all.cmd.json
@@ -39,7 +39,7 @@
         "description": "Pallet Benchmark for Trappist",
         "repos": ["trappist"],
         "args": {
-          "runtime":      { "label": "Runtime", "type_one_of": ["trappist", "stout"] }
+          "runtime":      { "label": "Runtime", "type_one_of": ["trappist", "stout"] },
           "target_dir":   { "label": "Target Directory", "type_string": "trappist" }
         }
       }

--- a/commands/bench/bench.cmd.json
+++ b/commands/bench/bench.cmd.json
@@ -115,6 +115,7 @@
           "subcommand": { "label": "Subcommand", "type_one_of": ["runtime", "xcm"] },
           "runtime":    { "label": "Runtime", "type_one_of": ["trappist", "stout"] },
           "pallet":     { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" }
+          "target_dir": { "label": "Target Directory", "type_string": "trappist" }
         }
       }
     }

--- a/commands/bench/bench.cmd.json
+++ b/commands/bench/bench.cmd.json
@@ -114,7 +114,7 @@
         "args": {
           "subcommand": { "label": "Subcommand", "type_one_of": ["runtime", "xcm"] },
           "runtime":    { "label": "Runtime", "type_one_of": ["trappist", "stout"] },
-          "pallet":     { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" }
+          "pallet":     { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "target_dir": { "label": "Target Directory", "type_string": "trappist" }
         }
       }

--- a/commands/bench/lib/bench-all-trappist.sh
+++ b/commands/bench/lib/bench-all-trappist.sh
@@ -2,15 +2,8 @@
 
 # Runs all benchmarks for all pallets, for a given runtime, provided by $1
 
-# This is a workaround for `UnknownOpcode(192)` error.
-# TODO. Remove this when migrated to 0.9.42+
-echo "[+] Apply workaround... (remove after 0.9.42+)"
-rustup toolchain install nightly-2023-01-01 --profile minimal --component rustfmt
-rustup target add wasm32-unknown-unknown --toolchain nightly-2023-01-01
-ln -sfn /usr/local/rustup/toolchains/nightly-2023-01-01-x86_64-unknown-linux-gnu /usr/local/rustup/toolchains/nightly-x86_64-unknown-linux-gnu
-echo "Toolchains available:"
-rustup toolchain list
-
+echo "Rust setup:"
+rustup show
 
 runtime="$1"
 chain="${runtime}-dev"


### PR DESCRIPTION
- removes workaround that was needed to build trappist before 0.9.42
- resolves https://github.com/paritytech/trappist/issues/231
- updates trappist scripts to the latest version of command-bot