### PR TITLE
Added new `asset-hub-rococo`

### DIFF
--- a/commands/bench-overhead/bench-overhead.cmd.json
+++ b/commands/bench-overhead/bench-overhead.cmd.json
@@ -32,7 +32,7 @@
         "description": "Runs `benchmark overhead` and commits back to PR the updated `extrinsic_weights.rs` files",
         "repos": ["cumulus", "polkadot-sdk"],
         "args": {
-          "runtime":      { "label": "Runtime", "type_one_of": ["asset-hub-polkadot", "asset-hub-kusama", "asset-hub-westend"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["asset-hub-polkadot", "asset-hub-kusama", "asset-hub-westend", "asset-hub-rococo"] },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" }
         }
       },

--- a/commands/bench/bench.cmd.json
+++ b/commands/bench/bench.cmd.json
@@ -36,7 +36,7 @@
         "repos": ["cumulus", "polkadot-sdk"],
         "args": {
           "subcommand":   { "label": "Subcommand", "type_one_of": ["pallet", "xcm"] },
-          "runtime":      { "label": "Runtime", "type_one_of": ["asset-hub-polkadot", "asset-hub-kusama", "asset-hub-westend"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["asset-hub-polkadot", "asset-hub-kusama", "asset-hub-westend", "asset-hub-rococo"] },
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "assets" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" }

--- a/commands/bench/lib/bench-all-cumulus.sh
+++ b/commands/bench/lib/bench-all-cumulus.sh
@@ -78,6 +78,7 @@ cargo build --profile $profile --locked --features=runtime-benchmarks
 run_cumulus_bench assets asset-hub-kusama
 run_cumulus_bench assets asset-hub-polkadot
 run_cumulus_bench assets asset-hub-westend
+run_cumulus_bench assets asset-hub-rococo
 
 # Collectives
 run_cumulus_bench collectives collectives-polkadot


### PR DESCRIPTION
## Summary

We are adding new test runtime `asset-hub-rococo` [here](https://github.com/paritytech/polkadot-sdk/pull/1215) and we want to `bot bench` to support it for benchmarks.

Actual error from monorepo:
https://github.com/paritytech/polkadot-sdk/pull/1215#issuecomment-1721127929