### PR TITLE
Remove system parachain native runtimes after polkadot-sdk #1737

### DIFF
--- a/commands/bench-all/bench-all.cmd.json
+++ b/commands/bench-all/bench-all.cmd.json
@@ -24,7 +24,7 @@
         "description": "Pallet + Overhead Benchmark for Polkadot",
         "repos": ["polkadot-sdk"],
         "args": {
-          "runtime":      { "label": "Runtime", "type_one_of": ["kusama", "polkadot", "rococo", "westend"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["rococo", "westend"] },
           "target_dir":   { "label": "Target Directory", "type_string":"polkadot" }
         }
       },

--- a/commands/bench-overhead/bench-overhead.cmd.json
+++ b/commands/bench-overhead/bench-overhead.cmd.json
@@ -17,7 +17,7 @@
         "description": "Runs `benchmark overhead` and commits back to PR the updated `extrinsic_weights.rs` files",
         "repos": ["polkadot-sdk"],
         "args": {
-          "runtime":      { "label": "Runtime", "type_one_of": ["polkadot", "kusama", "rococo", "westend"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["rococo", "westend"] },
           "target_dir":   { "label": "Target Directory", "type_string": "polkadot" }
         }
       },
@@ -32,7 +32,7 @@
         "description": "Runs `benchmark overhead` and commits back to PR the updated `extrinsic_weights.rs` files",
         "repos": ["polkadot-sdk"],
         "args": {
-          "runtime":      { "label": "Runtime", "type_one_of": ["asset-hub-polkadot", "asset-hub-kusama", "asset-hub-westend", "asset-hub-rococo"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["asset-hub-westend", "asset-hub-rococo"] },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" }
         }
       },

--- a/commands/bench/bench.cmd.json
+++ b/commands/bench/bench.cmd.json
@@ -26,7 +26,7 @@
         "repos": ["command-bot-test", "polkadot-sdk"],
         "args": {
           "subcommand":   { "label": "Subcommand", "type_one_of": ["runtime", "xcm"] },
-          "runtime":      { "label": "Runtime", "type_one_of": ["polkadot", "kusama", "rococo", "westend"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["rococo", "westend"] },
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "target_dir":   { "label": "Target Directory", "type_string": "polkadot" }
         }
@@ -36,7 +36,7 @@
         "repos": ["polkadot-sdk"],
         "args": {
           "subcommand":   { "label": "Subcommand", "type_one_of": ["pallet", "xcm"] },
-          "runtime":      { "label": "Runtime", "type_one_of": ["asset-hub-polkadot", "asset-hub-kusama", "asset-hub-westend", "asset-hub-rococo"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["asset-hub-westend", "asset-hub-rococo"] },
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "assets" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" }
@@ -47,7 +47,7 @@
         "repos": ["polkadot-sdk"],
         "args": {
           "subcommand":   { "label": "Subcommand", "type_one_of": ["pallet", "xcm"] },
-          "runtime":      { "label": "Runtime", "type_one_of": ["collectives-polkadot"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["collectives-westend"] },
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "collectives" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" }
@@ -58,7 +58,7 @@
         "repos": ["polkadot-sdk"],
         "args": {
           "subcommand":   { "label": "Subcommand", "type_one_of": ["pallet", "xcm"] },
-          "runtime":      { "label": "Runtime", "type_one_of": ["bridge-hub-polkadot", "bridge-hub-kusama", "bridge-hub-rococo"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["bridge-hub-rococo"] },
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "bridge-hubs" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" }
@@ -80,7 +80,7 @@
         "repos": ["polkadot-sdk"],
         "args": {
           "subcommand":   { "label": "Subcommand", "type_one_of": ["pallet"] },
-          "runtime":      { "label": "Runtime", "type_one_of": ["glutton-kusama", "glutton-kusama-dev-1300"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["glutton-westend", "glutton-westend-dev-1300"] },
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "glutton" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" }

--- a/commands/bench/lib/bench-all-cumulus.sh
+++ b/commands/bench/lib/bench-all-cumulus.sh
@@ -75,18 +75,14 @@ echo "[+] Compiling benchmarks..."
 cargo build --profile $profile --locked --features=runtime-benchmarks -p polkadot-parachain-bin
 
 # Assets
-run_cumulus_bench assets asset-hub-kusama
-run_cumulus_bench assets asset-hub-polkadot
 run_cumulus_bench assets asset-hub-westend
 run_cumulus_bench assets asset-hub-rococo
 
 # Collectives
-run_cumulus_bench collectives collectives-polkadot
+run_cumulus_bench collectives collectives-westend
 
 # Bridge Hubs
-run_cumulus_bench bridge-hubs bridge-hub-polkadot
-run_cumulus_bench bridge-hubs bridge-hub-kusama
 run_cumulus_bench bridge-hubs bridge-hub-rococo
 
 # Glutton
-run_cumulus_bench glutton glutton-kusama 1300
+run_cumulus_bench glutton glutton-westend 1300

--- a/commands/bench/lib/bench-pallet.sh
+++ b/commands/bench/lib/bench-pallet.sh
@@ -104,7 +104,7 @@ bench_pallet() {
       local runtime_dir="${out:-""}"
       local chain="$runtime"
 
-      # to support specifying parachain id from runtime name (e.g. ["glutton-kusama", "glutton-kusama-dev-1300"])
+      # to support specifying parachain id from runtime name (e.g. ["glutton-westend", "glutton-westend-dev-1300"])
       # If runtime ends with "-dev" or "-dev-\d+", leave as it is, otherwise concat "-dev" at the end of $chain
       if [[ ! "$runtime" =~ -dev(-[0-9]+)?$ ]]; then
           chain="${runtime}-dev"

--- a/commands/try-runtime/try-runtime.cmd.json
+++ b/commands/try-runtime/try-runtime.cmd.json
@@ -8,7 +8,7 @@
         "description": "Run try-runtime with specified runtime for Polkadot repo",
         "repos": ["polkadot", "command-bot-test"],
         "args": {
-          "chain":      { "label": "Chain", "type_one_of": ["polkadot", "kusama", "westend", "rococo"] },
+          "chain":      { "label": "Chain", "type_one_of": ["westend", "rococo"] },
           "target_path":{ "label": "Target Path", "type_string": "." },
           "chain_node": { "label": "Chain Node", "type_string": "polkadot" }
         }
@@ -17,7 +17,7 @@
         "description": "Run try-runtime with specified runtime for monorepo Polkadot SDK",
         "repos": ["polkadot-sdk"],
         "args": {
-          "chain":      { "label": "Chain", "type_one_of": ["polkadot", "kusama", "westend", "rococo"] },
+          "chain":      { "label": "Chain", "type_one_of": ["westend", "rococo"] },
           "target_path":{ "label": "Target Path", "type_string": "./polkadot" },
           "chain_node": { "label": "Chain Node", "type_string": "polkadot" }
         }

--- a/commands/try-runtime/try-runtime.cmd.json
+++ b/commands/try-runtime/try-runtime.cmd.json
@@ -9,7 +9,6 @@
         "repos": ["polkadot-sdk"],
         "args": {
           "chain":      { "label": "Chain", "type_one_of": ["westend", "rococo"] },
-          "target_path":{ "label": "Target Path", "type_string": "./polkadot" },
           "chain_node": { "label": "Chain Node", "type_string": "polkadot" }
         }
       },


### PR DESCRIPTION
Changes related to [`command-bot` #242](https://github.com/paritytech/command-bot/issues/242).

Removes ability to run benchmarks for the following:
- `asset-hub-kusama` and `asset-hub-polkadot`
- `bridge-hub-kusama` and `bridge-hub-polkadot`
- `collectives-polkadot`
- `glutton-kusama`

Adds the following to scripts:
- `collectives-westend`
- `glutton-westend`

To be merged after [this PR](https://github.com/paritytech/polkadot-sdk/pull/1737) in `polkadot-sdk` and along with [this PR](https://github.com/paritytech/command-bot/pull/243) in `command-bot`.