### PR TITLE
Add `collectives-westend` and `glutton-westend` benchmarks

### DIFF
--- a/commands/bench/bench.cmd.json
+++ b/commands/bench/bench.cmd.json
@@ -47,7 +47,7 @@
         "repos": ["polkadot-sdk"],
         "args": {
           "subcommand":   { "label": "Subcommand", "type_one_of": ["pallet", "xcm"] },
-          "runtime":      { "label": "Runtime", "type_one_of": ["collectives-polkadot"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["collectives-polkadot", "collectives-westend"] },
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "collectives" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" }
@@ -80,7 +80,7 @@
         "repos": ["polkadot-sdk"],
         "args": {
           "subcommand":   { "label": "Subcommand", "type_one_of": ["pallet"] },
-          "runtime":      { "label": "Runtime", "type_one_of": ["glutton-kusama", "glutton-kusama-dev-1300"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["glutton-kusama", "glutton-kusama-dev-1300", "glutton-westend", "glutton-westend-dev-1300"] },
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "glutton" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" }

--- a/commands/bench/lib/bench-all-cumulus.sh
+++ b/commands/bench/lib/bench-all-cumulus.sh
@@ -82,6 +82,7 @@ run_cumulus_bench assets asset-hub-rococo
 
 # Collectives
 run_cumulus_bench collectives collectives-polkadot
+run_cumulus_bench collectives collectives-westend
 
 # Bridge Hubs
 run_cumulus_bench bridge-hubs bridge-hub-polkadot
@@ -90,3 +91,4 @@ run_cumulus_bench bridge-hubs bridge-hub-rococo
 
 # Glutton
 run_cumulus_bench glutton glutton-kusama 1300
+run_cumulus_bench glutton glutton-westend 1300


### PR DESCRIPTION
Add collectives and glutton parachain westend benchmarks.

The removal of system parachain native runtimes [PR](https://github.com/paritytech/polkadot-sdk/pull/1737) is blocked until chainspecs and runtime APIs can be dealt with cleanly, in the meantime I have separated the addition of the new system parachains into [this PR](https://github.com/paritytech/polkadot-sdk/pull/2024) to enable merging these before the rest is ready.

This could be merged straight away as it is only additions from the other PR #52.