### PR TITLE
Enable benchmarking all pallets for a given runtime with bench-all

### DIFF
--- a/commands/bench-all/bench-all.cmd.json
+++ b/commands/bench-all/bench-all.cmd.json
@@ -45,6 +45,8 @@
               "bridge-hub-westend",
               "collectives-polkadot",
               "collectives-westend",
+              "coretime-rococo",
+              "coretime-westend",
               "contracts-rococo",
               "glutton-kusama",
               "glutton-westend"

--- a/commands/bench-all/bench-all.cmd.json
+++ b/commands/bench-all/bench-all.cmd.json
@@ -32,6 +32,24 @@
         "description": "Pallet Benchmark for Cumulus",
         "repos": ["polkadot-sdk"],
         "args": {
+          "runtime": {
+            "label": "Runtime",
+            "type_one_of": [
+              "asset-hub-kusama",
+              "asset-hub-polkadot",
+              "asset-hub-rococo",
+              "asset-hub-westend",
+              "bridge-hub-kusama",
+              "bridge-hub-polkadot",
+              "bridge-hub-rococo",
+              "bridge-hub-westend",
+              "collectives-polkadot",
+              "collectives-westend",
+              "contracts-rococo",
+              "glutton-kusama",
+              "glutton-westend"
+            ]
+          },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" }
         }
       },

--- a/commands/bench/lib/bench-all-cumulus.sh
+++ b/commands/bench/lib/bench-all-cumulus.sh
@@ -89,6 +89,9 @@ if [[ $runtime ]]; then
     collectives-*)
       category="collectives"
     ;;
+    coretime-*)
+      category="coretime"
+    ;;
     bridge-*)
       category="bridge-hubs"
     ;;

--- a/commands/bench/lib/bench-all-cumulus.sh
+++ b/commands/bench/lib/bench-all-cumulus.sh
@@ -110,7 +110,6 @@ if [[ $runtime ]]; then
 
   run_cumulus_bench $category $runtime $paraId
 
-  exit 0
 else # run all
   # Assets
   run_cumulus_bench assets asset-hub-rococo

--- a/commands/bench/lib/bench-all-cumulus.sh
+++ b/commands/bench/lib/bench-all-cumulus.sh
@@ -81,6 +81,7 @@ get_arg optional --runtime "$@"
 runtime="${out:-""}"
 
 if [[ $runtime ]]; then
+  paraId=""
   case "$runtime" in
     asset-*)
       category="assets"
@@ -96,7 +97,7 @@ if [[ $runtime ]]; then
     ;;
     glutton-*)
       category="glutton"
-      $paraId="1300"
+      paraId="1300"
     ;;
     *)
       echo "Unknown runtime: $runtime"


### PR DESCRIPTION
Add a runtime parameter to bench-all to allow benchmarking all pallets for a given runtime with one command