### PR TITLE
Add coretime parachain to benches

### DIFF
--- a/commands/bench/bench.cmd.json
+++ b/commands/bench/bench.cmd.json
@@ -53,6 +53,17 @@
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" }
         }
       },
+      "cumulus-coretime": {
+        "description": "Pallet Benchmark for Cumulus [coretime]",
+        "repos": ["polkadot-sdk"],
+        "args": {
+          "subcommand":   { "label": "Subcommand", "type_one_of": ["pallet", "xcm"] },
+          "runtime":      { "label": "Runtime", "type_one_of": ["coretime-rococo", "coretime-westend"] },
+          "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
+          "runtime_dir":  { "label": "Runtime Dir", "type_string": "coretime" },
+          "target_dir":   { "label": "Target Directory", "type_string": "cumulus" }
+        }
+      },
       "cumulus-bridge-hubs": {
         "description": "Pallet Benchmark for Cumulus [bridge-hubs]",
         "repos": ["polkadot-sdk"],

--- a/commands/bench/lib/bench-all-cumulus.sh
+++ b/commands/bench/lib/bench-all-cumulus.sh
@@ -84,6 +84,10 @@ run_cumulus_bench assets asset-hub-rococo
 run_cumulus_bench collectives collectives-polkadot
 run_cumulus_bench collectives collectives-westend
 
+# Coretime
+run_cumulus_bench coretime coretime-rococo
+run_cumulus_bench coretime coretime-westend
+
 # Bridge Hubs
 run_cumulus_bench bridge-hubs bridge-hub-polkadot
 run_cumulus_bench bridge-hubs bridge-hub-kusama


### PR DESCRIPTION
Coretime was merged to master in https://github.com/paritytech/polkadot-sdk/pull/1479

This just adds the ability to bench `coretime-rococo` and `coretime-westend`.