### PR TITLE
Add support for new extension benchmarking

### DIFF
--- a/commands/bench-all/bench-all.cmd.json
+++ b/commands/bench-all/bench-all.cmd.json
@@ -35,7 +35,7 @@
         "args": {
           "runtime":      { "label": "Runtime", "type_one_of": ["rococo", "westend"] },
           "target_dir":   { "label": "Target Directory", "type_string":"polkadot" },
-          "features": { "label": "Additional Features", "type_string": "riscv" }
+          "features": { "label": "Additional Features", "type_string": "" }
         }
       },
       "cumulus": {

--- a/commands/bench/bench.cmd.json
+++ b/commands/bench/bench.cmd.json
@@ -19,7 +19,8 @@
           "runtime":      { "label": "Runtime", "type_one_of": ["dev"] },
           "pallet":       { "label": "pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "target_dir":   { "label": "Target Directory", "type_string": "substrate" },
-          "features":     { "label": "AdditionalFeatures", "type_string": "riscv" }
+          "features":     { "label": "AdditionalFeatures", "type_string": "riscv" },
+          "machine":      { "label": "Machine", "type_string": "" }
         }
       },
       "polkadot-pallet": {
@@ -30,7 +31,8 @@
           "runtime":      { "label": "Runtime", "type_one_of": ["rococo", "westend"] },
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "target_dir":   { "label": "Target Directory", "type_string": "polkadot" },
-          "features":     { "label": "Additional Features", "type_string": "" }
+          "features":     { "label": "Additional Features", "type_string": "" },
+          "machine":      { "label": "Machine", "type_string": "" }
         }
       },
       "cumulus-assets": {
@@ -42,7 +44,8 @@
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "assets" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" },
-          "features":     { "label": "Additional Features", "type_string": "" }
+          "features":     { "label": "Additional Features", "type_string": "" },
+          "machine":      { "label": "Machine", "type_string": "" }
         }
       },
       "cumulus-collectives": {
@@ -54,7 +57,8 @@
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "collectives" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" },
-          "features":     { "label": "Additional Features", "type_string": "" }
+          "features":     { "label": "Additional Features", "type_string": "" },
+          "machine":      { "label": "Machine", "type_string": "" }
         }
       },
       "cumulus-coretime": {
@@ -66,7 +70,8 @@
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "coretime" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" },
-          "features":     { "label": "Additional Features", "type_string": "" }
+          "features":     { "label": "Additional Features", "type_string": "" },
+          "machine":      { "label": "Machine", "type_string": "" }
         }
       },
       "cumulus-bridge-hubs": {
@@ -78,7 +83,8 @@
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "bridge-hubs" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" },
-          "features":     { "label": "Additional Features", "type_string": "" }
+          "features":     { "label": "Additional Features", "type_string": "" },
+          "machine":      { "label": "Machine", "type_string": "" }
         }
       },
       "cumulus-contracts": {
@@ -90,7 +96,8 @@
           "runtime_dir":    { "label": "Runtime Dir", "type_string": "contracts" },
           "pallet":         { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "target_dir":     { "label": "Target Directory", "type_string": "cumulus" },
-          "features":     { "label": "Additional Features", "type_string": "" }
+          "features":       { "label": "Additional Features", "type_string": "" },
+          "machine":        { "label": "Machine", "type_string": "" }
         }
       },
       "cumulus-glutton": {
@@ -102,7 +109,8 @@
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "glutton" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" },
-          "features":     { "label": "Additional Features", "type_string": "" }
+          "features":     { "label": "Additional Features", "type_string": "" },
+          "machine":      { "label": "Machine", "type_string": "" }
         }
       },
       "cumulus-starters": {
@@ -114,7 +122,8 @@
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "starters" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" },
-          "features":     { "label": "Additional Features", "type_string": "" }
+          "features":     { "label": "Additional Features", "type_string": "" },
+          "machine":      { "label": "Machine", "type_string": "" }
         }
       },
       "cumulus-people": {
@@ -126,7 +135,8 @@
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "people" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" },
-          "features":     { "label": "Additional Features", "type_string": "" }
+          "features":     { "label": "Additional Features", "type_string": "" },
+          "machine":      { "label": "Machine", "type_string": "" }
         }
       },
       "cumulus-testing": {
@@ -138,7 +148,8 @@
           "pallet":       { "label": "Pallet", "type_rule": "^([a-z_]+)([:]{2}[a-z_]+)?$", "example": "pallet_name" },
           "runtime_dir":  { "label": "Runtime Dir", "type_string": "testing" },
           "target_dir":   { "label": "Target Directory", "type_string": "cumulus" },
-          "features":     { "label": "Additional Features", "type_string": "" }
+          "features":     { "label": "Additional Features", "type_string": "" },
+          "machine":      { "label": "Machine", "type_string": "" }
         }
       }
     }

--- a/commands/bench/lib/bench-all-substrate.sh
+++ b/commands/bench/lib/bench-all-substrate.sh
@@ -94,6 +94,16 @@ fi
 for PALLET in "${PALLETS[@]}"; do
   FOLDER="$(echo "${PALLET#*_}" | tr '_' '-')";
   WEIGHT_FILE="$output_path/frame/${FOLDER}/src/weights.rs"
+
+  # Special handling of custom weight paths.
+  if [ ["$PALLET" == "frame_system_extensions" || "$PALLET" == "frame-system-extensions"] ]; then
+    WEIGHT_FILE="$output_path/frame/system/src/extensions/weights.rs"
+  elif [ ["$PALLET" == "pallet_asset_conversion_tx_payment" || "$PALLET" == "pallet-asset-conversion-tx-payment"] ]; then
+    WEIGHT_FILE="$output_path/frame/transaction-payment/asset-conversion-tx-payment/src/weights.rs"
+  elif [ ["$PALLET" == "pallet_asset_tx_payment" || "$PALLET" == "pallet-asset-tx-payment"] ]; then
+    WEIGHT_FILE="$output_path/frame/transaction-payment/asset-tx-payment/src/weights.rs"
+  fi
+
   echo "[+] Benchmarking $PALLET with weight file $WEIGHT_FILE";
 
   OUTPUT=$(

--- a/commands/bench/lib/bench-all-substrate.sh
+++ b/commands/bench/lib/bench-all-substrate.sh
@@ -130,6 +130,9 @@ for PALLET in "${ALL_PALLETS[@]}"; do
   elif [ "$PALLET" == "pallet_asset_tx_payment" ] || [ "$PALLET" == "pallet-asset-tx-payment" ]
   then
     WEIGHT_FILE="$output_path/frame/transaction-payment/asset-tx-payment/src/weights.rs"
+  elif [ "$PALLET" == "tasks_example" ] || [ "$PALLET" == "tasks-example" ]
+  then
+    WEIGHT_FILE="$output_path/frame/examples/tasks/src/weights.rs"
   fi
 
   echo "[+] Benchmarking $PALLET with weight file $WEIGHT_FILE";

--- a/commands/bench/lib/bench-all-substrate.sh
+++ b/commands/bench/lib/bench-all-substrate.sh
@@ -119,6 +119,18 @@ for PALLET in "${ALL_PALLETS[@]}"; do
     echo "[+] Skipping $PALLET as it is in the excluded list."
     continue
   fi
+  
+  # Special handling of custom weight paths.
+  if [ "$PALLET" == "frame_system_extensions" ] || [ "$PALLET" == "frame-system-extensions" ]
+  then
+    WEIGHT_FILE="$output_path/frame/system/src/extensions/weights.rs"
+  elif [ "$PALLET" == "pallet_asset_conversion_tx_payment" ] || [ "$PALLET" == "pallet-asset-conversion-tx-payment" ]
+  then
+    WEIGHT_FILE="$output_path/frame/transaction-payment/asset-conversion-tx-payment/src/weights.rs"
+  elif [ "$PALLET" == "pallet_asset_tx_payment" ] || [ "$PALLET" == "pallet-asset-tx-payment" ]
+  then
+    WEIGHT_FILE="$output_path/frame/transaction-payment/asset-tx-payment/src/weights.rs"
+  fi
 
   echo "[+] Benchmarking $PALLET with weight file $WEIGHT_FILE";
 

--- a/commands/bench/lib/bench-all-substrate.sh
+++ b/commands/bench/lib/bench-all-substrate.sh
@@ -61,6 +61,7 @@ EXCLUDED_PALLETS=(
   "pallet_offences"
   # Only used for testing, does not need real weights.
   "frame_benchmarking_pallet_pov"
+  "pallet_example_authorization_tx_extension"
   "pallet_example_tasks"
   "pallet_example_basic"
   "pallet_example_split"
@@ -119,7 +120,7 @@ for PALLET in "${ALL_PALLETS[@]}"; do
     echo "[+] Skipping $PALLET as it is in the excluded list."
     continue
   fi
-  
+
   # Special handling of custom weight paths.
   if [ "$PALLET" == "frame_system_extensions" ] || [ "$PALLET" == "frame-system-extensions" ]
   then
@@ -133,6 +134,9 @@ for PALLET in "${ALL_PALLETS[@]}"; do
   elif [ "$PALLET" == "tasks_example" ] || [ "$PALLET" == "tasks-example" ]
   then
     WEIGHT_FILE="$output_path/frame/examples/tasks/src/weights.rs"
+  elif [ "$PALLET" == "pallet_asset_conversion_ops" ] || [ "$PALLET" == "pallet-asset-conversion-ops" ]
+  then
+    WEIGHT_FILE="$output_path/frame/asset-conversion/ops/src/weights.rs"
   fi
 
   echo "[+] Benchmarking $PALLET with weight file $WEIGHT_FILE";

--- a/commands/bench/lib/bench-pallet.sh
+++ b/commands/bench/lib/bench-pallet.sh
@@ -28,6 +28,9 @@ bench_pallet() {
   get_arg optional --features "$@"
   local additional_features="${out:-""}"
 
+  get_arg optional --machine "$@"
+  local machine="${out:-""}"
+
   local features="runtime-benchmarks"
   if [ -n "$additional_features" ]; then
     features+=",$additional_features"
@@ -73,6 +76,10 @@ bench_pallet() {
           die "Subcommand $subcommand is not supported for $target_dir in bench_pallet"
         ;;
       esac
+      
+      if [ -n "$machine" ]; then
+        $cargo_run_benchmarks -- benchmark machine --chain="$runtime" --allow-fail
+      fi
     ;;
     polkadot)
       # For backward compatibility: replace "-dev" with ""
@@ -106,6 +113,10 @@ bench_pallet() {
           die "Subcommand $subcommand is not supported for $target_dir in bench_pallet"
         ;;
       esac
+
+      if [ -n "$machine" ]; then
+        $cargo_run_benchmarks -- benchmark machine --chain="$runtime-dev" --allow-fail
+      fi
     ;;
     cumulus)
       get_arg required --runtime_dir "$@"
@@ -147,6 +158,10 @@ bench_pallet() {
           die "Subcommand $subcommand is not supported for $target_dir in bench_pallet"
         ;;
       esac
+      
+      if [ -n "$machine" ]; then
+        $cargo_run_benchmarks -- benchmark machine --chain="$chain" --allow-fail
+      fi
     ;;
     *)
       die "Repository $target_dir is not supported in bench_pallet"

--- a/commands/bench/lib/bench-pallet.sh
+++ b/commands/bench/lib/bench-pallet.sh
@@ -78,7 +78,7 @@ bench_pallet() {
       esac
       
       if [ -n "$machine" ]; then
-        $cargo_run_benchmarks -- benchmark machine --chain="$runtime" --allow-fail
+        $cargo_run_benchmarks --features="$features" -- benchmark machine --chain="$runtime" --allow-fail
       fi
     ;;
     polkadot)
@@ -115,7 +115,7 @@ bench_pallet() {
       esac
 
       if [ -n "$machine" ]; then
-        $cargo_run_benchmarks -- benchmark machine --chain="$runtime-dev" --allow-fail
+        $cargo_run_benchmarks --bin=polkadot --features="$features" -- benchmark machine --chain="$runtime-dev" --allow-fail
       fi
     ;;
     cumulus)
@@ -160,7 +160,7 @@ bench_pallet() {
       esac
       
       if [ -n "$machine" ]; then
-        $cargo_run_benchmarks -- benchmark machine --chain="$chain" --allow-fail
+        $cargo_run_benchmarks -p=polkadot-parachain-bin --features="$features" -- benchmark machine --chain="$chain" --allow-fail
       fi
     ;;
     *)


### PR DESCRIPTION
This PR adds support for new extension output directories in the `bench-all` subcommand.

Incidentally, the `riscv` additional feature was removed from the `bench-all polkadot` workflow in order to fix the compilation.